### PR TITLE
Fix: part missing in link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ A simple twig extension to provide rendering functions for the [PHP Debug Bar](h
 **Requirements:**
 
 * [Twig](https://github.com/fabpot/Twig)
-* [PHP Debug Bar](http://github.com/maximebf/php-debugba)
+* [PHP Debug Bar](http://github.com/maximebf/php-debugbar)
 
 ## Installation
 ```


### PR DESCRIPTION
The link to PHP Debug Bar was missing the last r